### PR TITLE
Fix documentation links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ethereum-based collectible avatars with on-chain artwork and metadata
 ## Documentation
 Developer setup, contract architecture, UML, and docs, trait hash bitmasking info, unit test output, 
 and more are available at:
-* https://dapp-wizards.github.io/Avastars-Contracts
+* https://nft42.github.io/Avastars-Contracts
 
 ## Repository Contents
 
@@ -15,7 +15,7 @@ Ethereum smart contracts for the Avastar project
 Scripts, data, and logs for preparing deployed contracts for use
 
 ### [/docs](docs)
-The [project documentation](https://dapp-wizards.github.io/Avastars-Contracts), processed and redeployed upon each 
+The [project documentation](https://nft42.github.io/Avastars-Contracts), processed and redeployed upon each 
 commit to Github.
 
 ### [/flat](flat)
@@ -178,7 +178,7 @@ Summary
 > Final cost:          0.018533242 ETH
 ```
 
-### Setup - [Artist Attribution](https://github.com/Dapp-Wizards/Avastars-Contracts/tree/master/data#set-artist-attribution) (Rinkeby example)
+### Setup - [Artist Attribution](https://github.com/nft42/Avastars-Contracts/tree/master/data#set-artist-attribution) (Rinkeby example)
 #### Must edit data/attribution/set-attribution.js, set artist info first!
 ```
 truffle(rinkeby)> exec data/set-attribution.js
@@ -188,7 +188,7 @@ Adding artist attribution for Generation 1...
 Gas used: 114231
 ```
 
-### Setup - [Create Traits](https://github.com/Dapp-Wizards/Avastars-Contracts/tree/master/data#create-traits) (Rinkeby example)
+### Setup - [Create Traits](https://github.com/nft42/Avastars-Contracts/tree/master/data#create-traits) (Rinkeby example)
 #### Must edit data/traits/create-traits.js, set NETWORK constant, and comment out safety catch first!
 ```
 truffle(rinkeby)> exec data/create-traits.js
@@ -206,7 +206,7 @@ Adding traits to contract...
 .
 ```
 
-### Setup - [Create Promos](https://github.com/Dapp-Wizards/Avastars-Contracts/tree/master/data#create-promos) (Rinkeby example)
+### Setup - [Create Promos](https://github.com/nft42/Avastars-Contracts/tree/master/data#create-promos) (Rinkeby example)
 #### Must edit data/promos/create-promos.js, set NETWORK constant, and comment out safety catch first!
 ```
 truffle(rinkeby)> exec data/create-promos.js


### PR DESCRIPTION
This fixes #2
* Happened when the organization name was changed
* change is just a find/replace of dapp-wizards with nft42 in README.md

nft42 devs, you should also change:
* The info section of the github repo: 

  <img width="327" alt="Screen Shot 2021-05-13 at 2 02 02 PM" src="https://user-images.githubusercontent.com/871933/118166705-ce083000-b3f3-11eb-8c23-fbc5ad2400a8.png">

<img width="456" alt="Screen Shot 2021-05-13 at 1 54 08 PM" src="https://user-images.githubusercontent.com/871933/118166520-913c3900-b3f3-11eb-99b7-0b2a73faad97.png">

* The documentation link at the bottom of the [Avastars-Marketplace app](https://avastars.io)'s intro page: 

  <img width="390" alt="Screen Shot 2021-05-13 at 2 05 52 PM" src="https://user-images.githubusercontent.com/871933/118167119-571f6700-b3f4-11eb-880f-def552dbc7f9.png">